### PR TITLE
Use cron syntax in Renovate schedules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,6 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": ["github>rainstormy/presets-renovate"],
-	"schedule": [
-		"after 5pm every weekday",
-		"before 7am every weekday",
-		"every weekend"
-	],
+	"schedule": ["* 0-6,17-23 * * mon-fri", "* * * * sat,sun"],
 	"timezone": "Europe/Copenhagen"
 }


### PR DESCRIPTION
The `@breejs/later` syntax has been deprecated:
https://docs.renovatebot.com/configuration-options/#schedule